### PR TITLE
Juno: map TSP memory in bl31

### DIFF
--- a/plat/arm/board/common/board_css_common.c
+++ b/plat/arm/board/common/board_css_common.c
@@ -74,6 +74,7 @@ const mmap_region_t plat_arm_mmap[] = {
 	V2M_MAP_IOFPGA,
 	CSS_MAP_DEVICE,
 	SOC_CSS_MAP_DEVICE,
+	ARM_MAP_TSP_SEC_MEM,
 	{0}
 };
 #endif


### PR DESCRIPTION
Maps TSP memory in bl31 to allow the OP-TEE dispatcher to initialize
OP-TEE (bl32).

Signed-off-by: Jens Wiklander jens.wiklander@linaro.org
